### PR TITLE
Fix "Black Background" on Other Browsers

### DIFF
--- a/lib/template.svg
+++ b/lib/template.svg
@@ -4,7 +4,7 @@
 <rect width="30" height="20" fill="#555"/>
 <rect x="30" width="50" height="20" fill="#4c1"/>
 
-<rect rx="3" width="80" height="20" fill="url(#a)"/>
+<rect rx="3" width="80" height="20" fill="transparent"/>
 	<g fill="#fff" text-anchor="middle"
     font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
 	    <text x="15" y="14">hits</text>


### PR DESCRIPTION
Before (IE 11): ![image](https://user-images.githubusercontent.com/17762324/32601969-0cd55fec-c50a-11e7-95b3-b4ec3097cc7d.png)
After (IE 11): ![image](https://user-images.githubusercontent.com/17762324/32601993-2202d228-c50a-11e7-9500-707c46d5de99.png)

This basically fixes the "Black Background" bug on other browsers other than Chrome... :)

Tests: I only have Chrome and IE Installed but this should work just fine on other browsers (Tested on an online "Browser Compatibility testing platform")