### PR TITLE
Fix domain name migration

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at github@dwyl.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at github@dwyl.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Build Status](https://img.shields.io/travis/dwyl/hits/master.svg?style=flat-square)](https://travis-ci.org/dwyl/hits)
 [![codecov.io](https://img.shields.io/codecov/c/github/dwyl/hits/master.svg?style=flat-square)](http://codecov.io/github/dwyl/hits?branch=master)
-[![HitCount](http://hits.dwyl.io/dwyl/hits.svg)](https://github.com/dwyl/hits)
+[![HitCount](http://hits.dwyl.com/dwyl/hits.svg)](https://github.com/dwyl/hits)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/hits/issues/74)
 
 <!-- Docs badge not working ... if you have time to help investigate, please do.
@@ -109,7 +109,7 @@ how it's implemented.
 
 > If you simply want to display a "hit count badge"
 in your project's GitHub page, visit:
-http://hits.dwyl.io
+http://hits.dwyl.com
 to get the Markdown!
 
 
@@ -487,8 +487,8 @@ with the markup relevant to the Hits homepage:
 ```html
 <h2 class="bg-teal white h-25 tc ttu f1 lh-title lh-solid mt0 pa2 pb3 mb0 pb0">
   Hits!
-  <a href="http://hits.dwyl.io/" >
-    <img src="http://hits.dwyl.io/dwyl/homepage.svg" alt="Hit Count" class="pa0 ba bw1 b--white">
+  <a href="http://hits.dwyl.com/" >
+    <img src="http://hits.dwyl.com/dwyl/homepage.svg" alt="Hit Count" class="pa0 ba bw1 b--white">
   </a>
 </h2>
 <h4 class="mt0 tc fw5 f5 teal pa2 mb0">
@@ -525,7 +525,7 @@ with the markup relevant to the Hits homepage:
 
 <h3 class="mt3 fw5 tc db f3 bg-teal white pa2">Your Badge <em>Markdown:</em></h3>
 <pre id="badge" class="fw4 ba bw1 pa3 ma2" style="white-space: pre-wrap; word-break: keep-all;">
-  [![HitCount](http://hits.dwyl.io/{username}/{repo}.svg)](http://hits.dwyl.io/{username}/{repo})
+  [![HitCount](http://hits.dwyl.com/{username}/{repo}.svg)](http://hits.dwyl.com/{username}/{repo})
 </pre>
 
 <p class="pl2" id="nojs">

--- a/lib/hits_web/templates/page/index.html.eex
+++ b/lib/hits_web/templates/page/index.html.eex
@@ -1,7 +1,7 @@
 <h2 class="bg-teal white h-25 tc ttu f1 lh-title lh-solid mt0 pa2 pb3 mb0 pb0">
   Hits!
-  <a href="http://hits.dwyl.io/" >
-    <img src="http://hits.dwyl.io/homepage.svg" alt="Hit Count" class="pa0 ba bw1 b--white">
+  <a href="http://hits.dwyl.com/" >
+    <img src="http://hits.dwyl.com/homepage.svg" alt="Hit Count" class="pa0 ba bw1 b--white">
   </a>
 </h2>
 <h4 class="mt0 tc fw5 f5 teal pa2 mb0">
@@ -38,7 +38,7 @@
 
 <h3 class="mt3 fw5 tc db f3 bg-teal white pa2">Your Badge <em>Markdown:</em></h3>
 <pre id="badge" class="fw4 ba bw1 pa3 ma2" style="white-space: pre-wrap; word-break: keep-all;">
-  [![HitCount](http://hits.dwyl.io/{username}/{repo}.svg)](http://hits.dwyl.io/{username}/{repo})
+  [![HitCount](http://hits.dwyl.com/{username}/{repo}.svg)](http://hits.dwyl.com/{username}/{repo})
 </pre>
 
 <p class="pl2" id="nojs">


### PR DESCRIPTION
There are still unchanged links on some other repositories, in the site (hits.dwyl.com), and the description of _this_ repo.