### PR TITLE
[PR] Updating Dockerfile to build on elixir `1.14`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###
 ### Fist Stage - Building the Release
 ###
-FROM hexpm/elixir:1.12.1-erlang-24.0.1-alpine-3.13.3 AS build
+FROM hexpm/elixir:1.17.3-erlang-27.2.1-alpine-3.21.2 AS build
 
 # install build dependencies
 RUN apk add --no-cache build-base npm
@@ -57,7 +57,7 @@ RUN mix do compile, release
 ###
 
 # prepare release docker image
-FROM alpine:3.13.3 AS app
+FROM alpine:3.21.2 AS app
 RUN apk add --no-cache libstdc++ openssl ncurses-libs
 
 WORKDIR /app


### PR DESCRIPTION
fixes #347 

This PR bumps both the elixir version and `alpine` version in the `Dockerfile`, which is the likely culprit for the deploy workflow to fail ([according to the Elixir Forums](https://elixirforum.com/t/fail-to-deploy-1-14-0-via-docker/49945/9)).

Our `mix.exs` requires `elixir: "~> 1.14"`, so this change makes sense, mostly because we have dependencies like `ecto` that rely on APIs that are aren't available on the current `1.12` that is being used.